### PR TITLE
Add a C++ test outline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   tests:
     runs-on: ubuntu-latest
     steps:
@@ -18,3 +17,23 @@ jobs:
       with:
         python-version: '3.12'
     - run: pip install kaitaistruct
+
+  test-cpp:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install compiler
+      run: sudo apt install cmake build-essential
+
+    # The version here should match the one in ci/cpp/CMakeLists.txt
+    - name: Install kaitai-struct-compiler
+      run: |
+        curl -LO https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.10/kaitai-struct-compiler_0.10_all.deb
+        sudo apt install kaitai-struct-compiler_0.10_all.deb
+
+    - name: Build C++ test executable
+      run: |
+        cd ci/cpp
+        cmake -S . -B build
+        cmake --build build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install compiler
-      run: sudo apt install cmake build-essential
+      run: sudo apt install cmake build-essentials
 
     # The version here should match the one in ci/cpp/CMakeLists.txt
     - name: Install kaitai-struct-compiler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install compiler
-      run: sudo apt install cmake build-essentials
+      run: |
+        sudo apt update -y
+        sudo apt install -y cmake build-essential
 
     # The version here should match the one in ci/cpp/CMakeLists.txt
     - name: Install kaitai-struct-compiler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install kaitai-struct-compiler
       run: |
         curl -LO https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.10/kaitai-struct-compiler_0.10_all.deb
-        sudo apt install kaitai-struct-compiler_0.10_all.deb
+        sudo apt install ./kaitai-struct-compiler_0.10_all.deb
 
     - name: Build C++ test executable
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install kitware cmake archive
       run: |
         curl -LO https://apt.kitware.com/kitware-archive.sh
-        bash kitware-archive.sh
+        sudo bash kitware-archive.sh
 
     - name: Install compiler and cmake
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install compiler
+    # Need for a recent version of cmake
+    - name: Install kitware cmake archive
+      run: |
+        curl -LO https://apt.kitware.com/kitware-archive.sh
+        bash kitware-archive.sh
+
+    - name: Install compiler and cmake
       run: |
         sudo apt update -y
-        sudo apt install -y cmake build-essential
+        sudo apt install -y build-essential cmake
 
     # The version here should match the one in ci/cpp/CMakeLists.txt
     - name: Install kaitai-struct-compiler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install kaitai-struct-compiler
       run: |
         curl -LO https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.10/kaitai-struct-compiler_0.10_all.deb
-        sudo apt install ./kaitai-struct-compiler_0.10_all.deb
+        sudo apt install -y ./kaitai-struct-compiler_0.10_all.deb
 
     - name: Build C++ test executable
       run: |

--- a/ci/cpp/CMakeLists.txt
+++ b/ci/cpp/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.26)
+include(FetchContent)
+project(test-cpp CXX)
+
+# Version of the kaitai_struct_cpp_stl_runtime
+# Should match that of the kaitai-struct-compiler
+set(KSCSR_VERSION "0.10")
+
+set(kaitai_struct_cpp_stl_runtime_BUILD_TESTS OFF CACHE INTERNAL
+    "Disable tests in katai_struct_cpp_stl build" FORCE)
+
+FetchContent_Declare(
+  kaitai_struct_cpp_stl_runtime
+  GIT_REPOSITORY https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime.git
+  GIT_TAG        ${KSCSR_VERSION}
+  GIT_SHALLOW    ON
+  FIND_PACKAGE_ARGS
+)
+
+FetchContent_MakeAvailable(kaitai_struct_cpp_stl_runtime)
+
+# Check kaitai-struct-compiler version
+execute_process(
+  COMMAND bash -c "kaitai-struct-compiler --version | awk '{ print $2 }'"
+  OUTPUT_VARIABLE KSC_VERSION
+)
+
+if(NOT ${KSC_VERSION} STREQUAL ${KSCSR_VERSION})
+  message(FATAL "kaitai-struct-compiler version ${KSC_VERSION} does not match kaitai_struct_cpp_stl_runtime-struct version ${KSCSR_VERSION}")
+endif()
+
+# Convenient link to the directory containing the ksy files
+set(TEMPLATE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../src/tablestream/templates)
+
+# Generate the cpp files from metadata.ksy
+add_custom_command(OUTPUT dtype.cpp metadata.cpp VERBATIM
+    DEPENDS ${TEMPLATE_DIR}/metadata.ksy
+    COMMAND kaitai-struct-compiler -t cpp_stl --cpp-standard=11
+            ${TEMPLATE_DIR}/metadata.ksy
+)
+
+add_executable(test-cpp dtype.cpp metadata.cpp test.cpp)
+target_include_directories(test-cpp PRIVATE ${kaitai_struct_cpp_stl_runtime_SOURCE_DIR})
+target_link_libraries(test-cpp PRIVATE kaitai_struct_cpp_stl_runtime)
+# Allows compilation to go further, but these should be fixed
+target_compile_options(test-cpp PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-fpermissive>
+    $<$<CXX_COMPILER_ID:Clang>:-fpermissive>
+)

--- a/ci/cpp/CMakeLists.txt
+++ b/ci/cpp/CMakeLists.txt
@@ -32,16 +32,36 @@ endif()
 # Convenient link to the directory containing the ksy files
 set(TEMPLATE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../src/tablestream/templates)
 
-# Generate the cpp files from metadata.ksy
+# Generate the cpp files from the various ksy files
 add_custom_command(OUTPUT dtype.cpp metadata.cpp VERBATIM
-    DEPENDS ${TEMPLATE_DIR}/metadata.ksy
-    COMMAND kaitai-struct-compiler -t cpp_stl --cpp-standard=11
-            ${TEMPLATE_DIR}/metadata.ksy
+  DEPENDS ${TEMPLATE_DIR}/metadata.ksy
+  COMMAND kaitai-struct-compiler -t cpp_stl --cpp-standard=11
+          ${TEMPLATE_DIR}/metadata.ksy
 )
 
-add_executable(test-cpp dtype.cpp metadata.cpp test.cpp)
-target_include_directories(test-cpp PRIVATE ${kaitai_struct_cpp_stl_runtime_SOURCE_DIR})
-target_link_libraries(test-cpp PRIVATE kaitai_struct_cpp_stl_runtime)
+add_custom_command(OUTPUT lock.cpp VERBATIM
+  DEPENDS ${TEMPLATE_DIR}/lock.ksy
+  COMMAND kaitai-struct-compiler -t cpp_stl --cpp-standard=11
+          ${TEMPLATE_DIR}/lock.ksy
+)
+
+add_custom_command(OUTPUT standard_storage_manager.cpp VERBATIM
+  DEPENDS ${TEMPLATE_DIR}/standard_storage_manager.ksy
+  COMMAND kaitai-struct-compiler -t cpp_stl --cpp-standard=11
+          ${TEMPLATE_DIR}/standard_storage_manager.ksy
+)
+
+add_executable(test-cpp
+  dtype.cpp
+  lock.cpp
+  metadata.cpp
+  standard_storage_manager.cpp
+  test.cpp)
+
+target_include_directories(test-cpp
+  PRIVATE ${kaitai_struct_cpp_stl_runtime_SOURCE_DIR})
+target_link_libraries(test-cpp
+  PRIVATE kaitai_struct_cpp_stl_runtime)
 # Allows compilation to go further, but these should be fixed
 target_compile_options(test-cpp PRIVATE
     $<$<CXX_COMPILER_ID:GNU>:-fpermissive>

--- a/ci/cpp/README.rst
+++ b/ci/cpp/README.rst
@@ -1,0 +1,8 @@
+# C++ test case
+
+Basic test case testing that generated C++ code compiles and links.
+
+.. code-block:: bash
+
+  $ cmake -S . -B build
+  $ cmake --build build

--- a/ci/cpp/test.cpp
+++ b/ci/cpp/test.cpp
@@ -1,0 +1,5 @@
+#include <kaitai/kaitaistruct.h>
+
+int main(int argc, char * argv[]) {
+  return 0;
+}


### PR DESCRIPTION
@jrhosk @astrofrog I took the work done in https://github.com/radio-astro-tools/casa-formats-specification/commit/6c35a6032489121896bef597503c812253063aad a bit further here by building a C++ test case outline.

There are some failures when actually compiling the generated C++.

```cpp
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp: In constructor ‘dtype_t::int1_t::int1_t(kaitai::kstream*, kaitai::kstruct*, dtype_t*)’:
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:159:118: error: no matching function for call to ‘dtype_t::int8_t::int8_t()’
  159 | ::int1_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, dtype_t* p__root) : kaitai::kstruct(p__io) {
      |                                                                                                       ^

/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:38:1: note: candidate: ‘dtype_t::int8_t::int8_t(kaitai::kstream*, kaitai::kstruct*, dtype_t*)’
   38 | dtype_t::int8_t::int8_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, dtype_t* p__root) : kaitai::kstruct(p__io) {
      | ^~~~~~~
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:38:1: note:   candidate expects 3 arguments, 0 provided
In file included from /home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:3:
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.h:69:11: note: candidate: ‘constexpr dtype_t::int8_t::int8_t(const dtype_t::int8_t&)’
   69 |     class int8_t : public kaitai::kstruct {
      |           ^~~~~~
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.h:69:11: note:   candidate expects 1 argument, 0 provided
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp: In member function ‘void dtype_t::int1_t::_read()’:
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:166:29: warning: invalid user-defined conversion from ‘int8_t’ {aka ‘signed char’} to ‘const dtype_t::int8_t&’ [-fpermissive]
  166 |     m_value = m__io->read_s1();
      |               ~~~~~~~~~~~~~~^~
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:38:1: note: candidate is: ‘dtype_t::int8_t::int8_t(kaitai::kstream*, kaitai::kstruct*, dtype_t*)’ (near match)
   38 | dtype_t::int8_t::int8_t(kaitai::kstream* p__io, kaitai::kstruct* p__parent, dtype_t* p__root) : kaitai::kstruct(p__io) {
      | ^~~~~~~
/home/simon/code/casa-formats-specification/ci/cpp/build/dtype.cpp:38:1: note:   conversion of argument 1 would be ill-formed:
```

I'm just pushing this up in the hopes that it'll be useful, rather than any expectation that this needs to be dealt with in the near or even medium term: It's just good to know there might be bumps in the road.

I might some time to dig more on my side as I haven't found time to understand the interaction between the generated kaitai C++ and the compiler.

Just compiling the generated rust would also be valuable IMO.
